### PR TITLE
Resample fix

### DIFF
--- a/morph_utils/ccf.py
+++ b/morph_utils/ccf.py
@@ -362,7 +362,9 @@ def projection_matrix_for_swc(input_swc_file, mask_method = "tip_and_branch",
     
     # annotate each node
     if morph_df.empty:
-        print("Its empty")
+        
+        msg = "morph_df is empty, possibly caused by `morph_df = morph_df[morph_df['type'].isin(node_type_list)]`"
+        warnings.warn(msg)
         return input_swc_file, {} 
     
     morph_df['ccf_structure'] = morph_df.apply(lambda rw: full_name_to_abbrev_dict[get_ccf_structure( np.array([rw.x, rw.y, rw.z]) , name_map, annotation, True)], axis=1)
@@ -383,7 +385,6 @@ def projection_matrix_for_swc(input_swc_file, mask_method = "tip_and_branch",
 
     # determine ipsi/contra projections
     morph_df["ccf_structure_sided"] = morph_df.apply(lambda row: "ipsi_{}".format(row.ccf_structure) if row.z<z_midline else "contra_{}".format(row.ccf_structure), axis=1)
-    print(morph_df.head())
     # mask the morphology dataframe accordinagly
     if mask_method!="None":
             
@@ -405,26 +406,22 @@ def projection_matrix_for_swc(input_swc_file, mask_method = "tip_and_branch",
         morph_df_masked = morph_df[morph_df['ccf_structure_sided'].isin(keep_structs)]
         
     else:
+        print("Not masking projection matrix...")
         morph_df_masked = morph_df
-    print(keep_structs)
-    print(morph_df_masked.head())
+        
     # remove ventral targets and out of brain 
     ventral_targs = ["ipsi_{}".format(v) for v in vs_acronyms] + ["contra_{}".format(v) for v in vs_acronyms]
     targets_to_remove = ["ipsi_Out Of Cortex", "ipsi_root","contra_Out Of Cortex", "contra_root"] + ventral_targs
     morph_df_masked = morph_df_masked[~morph_df_masked['ccf_structure_sided'].isin(targets_to_remove)]
     
-    print(morph_df_masked.node_type.value_counts())
-    print("count method",count_method)
     # accomodate tip counting instead of axon length 
     if count_method != 'node':
         morph_df_masked = morph_df_masked[morph_df_masked['node_type']==count_method]
         spacing = 1
-    print(morph_df_masked.head())
     # qunatify projections per structure 
     n_nodes_per_structure = morph_df_masked.ccf_structure_sided.value_counts()
     axon_length_per_structure = n_nodes_per_structure*spacing
     specimen_projection_summary = axon_length_per_structure.to_dict()
-    print(specimen_projection_summary)
     return input_swc_file, specimen_projection_summary   
 
  

--- a/morph_utils/executable_scripts/projection_matrix_from_swc_directory.py
+++ b/morph_utils/executable_scripts/projection_matrix_from_swc_directory.py
@@ -13,14 +13,14 @@ class IO_Schema(ags.ArgSchema):
     projection_threshold = ags.fields.Int(default=0)
     normalize_proj_mat = ags.fields.Boolean(default=True)
     mask_method = ags.fields.Str(default="tip_and_branch",description = " 'tip_and_branch', 'branch', 'tip', or 'tip_or_branch' ")
-    tip_count = ags.fields.Boolean(default=False, description="when true, this will measure a matrix of number of tips instead of number of nodes")
+    count_method = ags.fields.String(default="node", description="should be a member of ['node','tip','branch']")
     annotation_path = ags.fields.Str(default="",description = "Optional. Path to annotation .nrrd file. Defaults to 10um ccf atlas")
     resolution = ags.fields.Int(default=10, description="Optional. ccf resolution (micron/pixel")
     volume_shape = ags.fields.List(ags.fields.Int, default=[1320, 800, 1140], description = "Optional. Size of input annotation")
     resample_spacing = ags.fields.Float(allow_none=True, default=None, description = 'internode spacing to resample input morphology with')
     run_host = ags.fields.String(default='local',description='either ["local" or "hpc"]. Will run either locally or submit jobs to the HPC')
     virtual_env_name = ags.fields.Str(default='skeleton_keys_4',description='Name of virtual conda env to activate on hpc. not needed if running local')
-    output_projection_csv = ags.fields.OutputFile(allow_none=True,default=None, description="output projection csv, when running local only")
+    output_projection_csv = ags.fields.OutputFile(description="output projection csv, when running local only")
 
     
 def normalize_projection_columns_per_cell(input_df, projection_column_identifiers=['ipsi', 'contra']):
@@ -44,7 +44,7 @@ def main(ccf_swc_directory,
          projection_threshold, 
          normalize_proj_mat,
          mask_method,
-         tip_count,
+         count_method,
          annotation_path,
          volume_shape,
          resample_spacing,
@@ -55,6 +55,8 @@ def main(ccf_swc_directory,
     
     if run_host not in ['local','hpc']:
         raise ValueError(f"Invalid run_host parameter entered ({run_host})")
+    if mask_method not in [None,'tip_and_branch', 'branch', 'tip', 'tip_or_branch']:
+        raise ValueError(f"Invalid mask_method provided {mask_method}")
     
     if annotation_path == "":
         annotation_path = None
@@ -69,13 +71,14 @@ def main(ccf_swc_directory,
                 os.mkdir(dd)
                 
     results = []
+    single_cell_job_ids = []
     for swc_fn in tqdm([f for f in os.listdir(ccf_swc_directory) if ".swc" in f]):
 
         swc_pth = os.path.abspath(os.path.join(ccf_swc_directory, swc_fn))
         
         if run_host=='local':
             res = projection_matrix_for_swc(input_swc_file=swc_pth, 
-                                tip_count = tip_count,
+                                count_method= count_method,
                                 mask_method = mask_method,
                                 annotation=None, 
                                 annotation_path = annotation_path, 
@@ -86,24 +89,25 @@ def main(ccf_swc_directory,
 
         else:
                 
-            output_projection_csv = os.path.join(single_sp_proj_dir, swc_fn.replace(".swc",".csv"))
+            this_output_projection_csv = os.path.join(single_sp_proj_dir, swc_fn.replace(".swc",".csv"))
             
-            if not os.path.exists(output_projection_csv):
+            if not os.path.exists(this_output_projection_csv):
                     
                 job_file = os.path.join(job_dir,swc_fn.replace(".swc",".sh"))
                 log_file = os.path.join(job_dir,swc_fn.replace(".swc",".log"))
                 
                 command = "morph_utils_extract_projection_matrix_single_cell "
                 command = command+ f" --input_swc_file '{swc_pth}'"
-                command = command+ f" --output_projection_csv {output_projection_csv}"
+                command = command+ f" --output_projection_csv {this_output_projection_csv}"
                 command = command+ f" --projection_threshold {projection_threshold}"
                 command = command+ f" --normalize_proj_mat {normalize_proj_mat}"
                 command = command+ f" --mask_method {mask_method}"
-                command = command+ f" --tip_count {tip_count}"
+                command = command+ f" --count_method {count_method}"
                 command = command+ f" --annotation_path {annotation_path}"
                 command = command+ f" --resolution {resolution}"
                 # command = command+ f" --volume_shape {volume_shape}"
-                command = command+ f" --resample_spacing {resample_spacing}"
+                if resample_spacing is not None:
+                    command = command+ f" --resample_spacing {resample_spacing}"
 
                     
                 activate_command = f"source activate {virtual_env_name}"
@@ -150,8 +154,70 @@ def main(ccf_swc_directory,
                 std_out = result.stdout.decode('utf-8')
 
                 job_id = std_out.split("Submitted batch job ")[-1].replace("\n", "")
-                time.sleep(0.1)
+                single_cell_job_ids.append(job_id)
+                # time.sleep(0.1)
+                
+    if run_host!='local':
+        # aggregate single projection files into proj mat
+        job_file = os.path.join(job_dir,"Projection_Aggregation.sh")
+        log_file = os.path.join(job_dir,"Projection_Aggregation.log")
+        agg_outdir = os.path.join(output_directory,'SingleCellProjections')
+        command = "morph_utils_aggregate_single_cell_projs "
+        command = command+ f" --output_projection_csv {output_projection_csv}"
+        command = command+ f" --output_directory {agg_outdir}"
+        command = command+ f" --projection_threshold {projection_threshold}"
+        command = command+ f" --normalize_proj_mat {normalize_proj_mat}"
+        command = command+ f" --mask_method {mask_method}"
+            
+        activate_command = f"source activate {virtual_env_name}"
+        command_list = [activate_command, command]
+                
+        slurm_kwargs = {
+            "--job-name": "AggregateProjs",
+            "--mail-type": "NONE",
+            "--cpus-per-task": "1",
+            "--nodes": "1",
+            "--kill-on-invalid-dep": "yes",
+            "--mem": "4gb",
+            "--time": "1:00:00",
+            "--partition": "celltypes",
+            "--output": log_file
+        }
+
+        dag_node = {
+            "job_file":job_file,
+            "slurm_kwargs":slurm_kwargs,
+            "slurm_commands":command_list
+        }
         
+        job_file = dag_node["job_file"]
+        slurm_kwargs = dag_node["slurm_kwargs"]
+        command_list = dag_node["slurm_commands"]
+
+        job_string_list = [f"#SBATCH {k}={v}" for k, v in slurm_kwargs.items()]
+        job_string_list = job_string_list + command_list
+        job_string_list = ["#!/bin/bash"] + job_string_list
+
+        if os.path.exists(job_file):
+            os.remove(job_file)
+
+        with open(job_file, 'w') as job_f:
+            for val in job_string_list:
+                job_f.write(val)
+                job_f.write('\n')
+                
+        command = "sbatch --dependency=afterany"
+        for p_jid in single_cell_job_ids:
+            command = command + f":{p_jid}"
+        command = command + " {}".format(job_file)
+        command_list = command.split(" ")
+        # print(command)
+        result = subprocess.run(command_list, stdout=subprocess.PIPE)
+        std_out = result.stdout.decode('utf-8')
+
+        job_id = std_out.split("Submitted batch job ")[-1].replace("\n", "")
+        
+       
     if results != []:
         
         output_projection_csv = output_projection_csv.replace(".csv", f"_{mask_method}.csv")

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,5 +26,6 @@ console_scripts =
     morph_utils_full_morph_soma_correction = morph_utils.executable_scripts.full_morphology_soma_correction:console_script
     morph_utils_extract_projection_matrix = morph_utils.executable_scripts.projection_matrix_from_swc_directory:console_script
     morph_utils_extract_projection_matrix_single_cell = morph_utils.executable_scripts.projection_matrix_for_single_cell:console_script
+    morph_utils_aggregate_single_cell_projs = morph_utils.executable_scripts.aggregate_single_cell_projection_csvs:console_script
     morph_utils_move_somas_left_hemisphere = morph_utils.executable_scripts.move_somas_to_left_hemisphere_swc_directory:console_script
     morph_utils_local_crop_ccf_swcs = morph_utils.executable_scripts.local_crop_ccf_swc_directory:console_script


### PR DESCRIPTION
This was intended to be a small edit to the resample function, but didnt realize I committed changes to projection matrix as well. Details below:
change how proj mat can be run (locally and hpc)
when hpc is used, create an aggregate function that groups the individual cells proj mat files into a full cell x target matrix
change how proj mat is extracted for efficiency, uses a morphology dataframe 
Now use `count_method` to support 1) node counting (which results in an axon length proj mat), 2) tip node counting (which results in # of tip nodes proj mat) and 3) branch node counting (which results in  # branch nodes proj mat)

The resampling fix was for a unique case. When the grandchild node of the soma was irreducible, that node would appear twice in the resampled morphology. 

e.g. resampling these nodes:
test_nodes = [
    {'id': 1, 'type': 1, 'x': 0, 'y': 0, 'z': 0, 'r': 1.0, 'parent': -1},  # Soma
    {'id': 2, 'type': 3, 'x': 1, 'y': 0, 'z': 0, 'r': 0.5, 'parent': 1},  # Branch point
    {'id': 3, 'type': 3, 'x': 2, 'y': 1, 'z': 0, 'r': 0.5, 'parent': 2},  # Leaf
    {'id': 4, 'type': 3, 'x': 2, 'y': -1, 'z': 0, 'r': 0.5, 'parent': 2}, # Leaf
]

would yield:

[{'id': 1, 'type': 1, 'x': 0, 'y': 0, 'z': 0, 'radius': 1.0, 'parent': -1},
 {'id': 2, 'type': 3, 'x': 1, 'y': 0, 'z': 0, 'radius': 0.5, 'parent': 1}, 
 {'id': 3, 'type': 3, 'x': 1, 'y': 0, 'z': 0, 'radius': 0.5, 'parent': 2}, # duplicate node as 2
 {'id': 4, 'type': 3, 'x': 2, 'y': -1, 'z': 0, 'radius': 0.5, 'parent': 3},
 {'id': 5, 'type': 3, 'x': 2, 'y': 1, 'z': 0, 'radius': 0.5, 'parent': 3}]

Which is not...wrong per say, but best to be fixed. 